### PR TITLE
FISH-10648 Change Payara Versioning to `-payara-1`

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extensions/avro/pom.xml
+++ b/extensions/avro/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/cdc-debezium/pom.xml
+++ b/extensions/cdc-debezium/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/extensions/cdc-mysql/pom.xml
+++ b/extensions/cdc-mysql/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/extensions/cdc-postgres/pom.xml
+++ b/extensions/cdc-postgres/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/extensions/csv/pom.xml
+++ b/extensions/csv/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/elasticsearch/elasticsearch-7/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-7/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extensions/grpc/pom.xml
+++ b/extensions/grpc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/hadoop-dist/files-azure/pom.xml
+++ b/extensions/hadoop-dist/files-azure/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-hadoop-dist</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/hadoop-dist/files-gcs/pom.xml
+++ b/extensions/hadoop-dist/files-gcs/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-hadoop-dist</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/hadoop-dist/files-s3/pom.xml
+++ b/extensions/hadoop-dist/files-s3/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <artifactId>hazelcast-jet-hadoop-dist</artifactId>
         <groupId>com.hazelcast.jet</groupId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extensions/hadoop-dist/hadoop-all/pom.xml
+++ b/extensions/hadoop-dist/hadoop-all/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-hadoop-dist</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/hadoop-dist/hadoop/pom.xml
+++ b/extensions/hadoop-dist/hadoop/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-hadoop-dist</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/hadoop-dist/pom.xml
+++ b/extensions/hadoop-dist/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/extensions/hadoop/pom.xml
+++ b/extensions/hadoop/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/kafka-connect/pom.xml
+++ b/extensions/kafka-connect/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/kafka/pom.xml
+++ b/extensions/kafka/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/kinesis/pom.xml
+++ b/extensions/kinesis/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/mapstore/pom.xml
+++ b/extensions/mapstore/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/mongodb/pom.xml
+++ b/extensions/mongodb/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/extensions/protobuf/pom.xml
+++ b/extensions/protobuf/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/python/pom.xml
+++ b/extensions/python/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/extensions/s3/pom.xml
+++ b/extensions/s3/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet-extensions</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/hazelcast-archunit-rules/pom.xml
+++ b/hazelcast-archunit-rules/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-build-utils/pom.xml
+++ b/hazelcast-build-utils/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-coverage-report/pom.xml
+++ b/hazelcast-coverage-report/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>hazelcast-root</artifactId>
         <groupId>com.hazelcast</groupId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/hazelcast-it/distribution-it/pom.xml
+++ b/hazelcast-it/distribution-it/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-it</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <artifactId>distribution-it</artifactId>

--- a/hazelcast-it/pom.xml
+++ b/hazelcast-it/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
     </parent>
 
     <artifactId>hazelcast-it</artifactId>

--- a/hazelcast-spring-tests/pom.xml
+++ b/hazelcast-spring-tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-spring/pom.xml
+++ b/hazelcast-spring/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-sql/pom.xml
+++ b/hazelcast-sql/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-tpc-engine/pom.xml
+++ b/hazelcast-tpc-engine/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -609,7 +609,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-tpc-engine</artifactId>
-            <version>5.4.0.payara-p1-SNAPSHOT</version>
+            <version>5.4.0-payara-1-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/modulepath-tests/pom.xml
+++ b/modulepath-tests/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>5.4.0.payara-p1-SNAPSHOT</version>
+        <version>5.4.0-payara-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-root</artifactId>
     <packaging>pom</packaging>
-    <version>5.4.0.payara-p1-SNAPSHOT</version>
+    <version>5.4.0-payara-1-SNAPSHOT</version>
     <name>Hazelcast Root</name>
     <description>Hazelcast In-Memory DataGrid</description>
     <url>http://www.hazelcast.com/</url>


### PR DESCRIPTION
`.payara-p1` isn't a valid number for Hazelcast to parse, and this will cause NPEs when (de)serializing and doing other actions