### PR TITLE
FISH-10661 Revert StringUtilTest#isNotBlank to v5.3.8

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/util/StringUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/StringUtilTest.java
@@ -163,18 +163,8 @@ class StringUtilTest extends HazelcastTestSupport {
     @Test
     void isNotBlank() {
         assertFalse(StringUtil.isNullOrEmptyAfterTrim("string"));
-        // null unicode character
-        assertFalse(StringUtil.isNullOrEmptyAfterTrim("\u0000"));
-        // Non-breaking space
-        assertFalse(StringUtil.isNullOrEmptyAfterTrim("\u00A0"));
-
         assertTrue(StringUtil.isNullOrEmptyAfterTrim("  "));
         assertTrue(StringUtil.isNullOrEmptyAfterTrim(""));
-        // Em quad
-        assertTrue(StringUtil.isNullOrEmptyAfterTrim("\u2001"));
-        // Tab
-        assertTrue(StringUtil.isNullOrEmptyAfterTrim("\t"));
-        assertTrue(StringUtil.isNullOrEmptyAfterTrim("\n\r  "));
         assertTrue(StringUtil.isNullOrEmptyAfterTrim(null));
     }
 


### PR DESCRIPTION
Commit 53fcc40cdbf99b85fbb1d083eda4b1d3e9e5ca21 changed this method to use `isBlank`, which doesn't exist on Java 8.
As such, these extra tests for unicode characters don't make sense.