### PR TITLE
FISH-10659 Use a different option in AsyncServerSocketOptionsTest

### DIFF
--- a/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncServerSocketOptionsTest.java
+++ b/hazelcast-tpc-engine/src/test/java/com/hazelcast/internal/tpcengine/net/AsyncServerSocketOptionsTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertTrue;
 
 public abstract class AsyncServerSocketOptionsTest {
 
-    private static final Option<Boolean> SUPPORTED_OPTION = SO_REUSEPORT;
+    private static final Option<Boolean> SUPPORTED_OPTION = SO_REUSEADDR;
     private final List<Reactor> reactors = new ArrayList<>();
 
     public abstract ReactorBuilder newReactorBuilder();


### PR DESCRIPTION
`SO_REUSEPORT` is not a supported option in Java 8.
The test itself is not trying to test setting that option, there is another test for that, the test is just trying to test setting a supported option. `SO_REUSEADDR` is available in both Java versions, so I have set it to use that.