### PR TITLE
FISH-10968 Fix JavaX Annotations OSGI Import

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -352,6 +352,8 @@
                                     sun.misc;resolution:=optional,
                                     javax.cache;resolution:=optional,
                                     javax.cache.*;resolution:=optional,
+                                    javax.annotation;resolution:=optional,
+                                    javax.annotation.*;resolution:=optional,
                                     org.apache.log4j;resolution:=optional,
                                     org.apache.log4j.spi;resolution:=optional,
                                     org.apache.logging.log4j;resolution:=optional,


### PR DESCRIPTION
`javax.annotations.*` is pulled in by a different dependency, the import is now forcibly set to optional.